### PR TITLE
Created the RssFeedService and utilised in RssFeedController to fetch rss data

### DIFF
--- a/app/Http/Controllers/RssFeedController.php
+++ b/app/Http/Controllers/RssFeedController.php
@@ -2,47 +2,65 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Support\Facades\Http;
+use App\Services\RssFeedService;
 use Illuminate\Support\Facades\Log;
 use SimpleXMLElement;
 
 class RssFeedController extends Controller
 {
-    public function getRssFeed($section)
+    protected $rssFeedService;
+
+    public function __construct(RssFeedService $rssFeedService)
     {
-        $response = Http::get(env('GUARDAIN_URL').'sections', [
-            'q' => $section,
-            'api-key' => 'test',
-            'format' => 'json',
-        ]);
-
-        if ($response->failed()) {
-            return null;
-        }
-
-        $data = $response->json();
-        $rssFeed = $this->convertToRss($data);
-
-        return response($rssFeed, 200)->header('Content-Type', 'application/rss+xml');
+        $this->rssFeedService = $rssFeedService;
     }
 
-    private function convertToRss($data)
+    /**
+     * Fetches the RSS feed for a given section.
+     * @param string $section The section for which the RSS feed is to be fetched.
+     * @return Returns the RSS feed in XML format, or an error response if fetching fails
+     * @throws \Exception If an error occurs while fetching the RSS feed or if the service fails
+     */
+    public function getRssFeed($section)
     {
-        $rss = new SimpleXMLElement('<rss/>');
-        $rss->addAttribute('version', '2.0');
-        $channel = $rss->addChild('channel');
-        $channel->addChild('title', 'The Guardian RSS Feed');
-        $channel->addChild('link', 'https://www.theguardian.com');
+        try {
+            $rssFeed = $this->rssFeedService->fetchRssFeed($section); // Fetch the RSS feed using the service
+            return response($rssFeed, 200)
+                ->header('Content-Type', 'application/rss+xml');
 
-        foreach ($data['response']['results'] as $article) {
-            Log::info('Response from GUARDAIN', ['article' => $article]);
-
-            $rssItem = $channel->addChild('item');
-            $rssItem->addChild('title', htmlspecialchars($article['webTitle']));
-            $rssItem->addChild('link', htmlspecialchars($article['webUrl']));
+        } catch (\Exception $error) {
+            // Log the exception using Monolog
+            Log::error('An error occurred while fetching the RSS feed', [
+                'error_message' => $error->getMessage(),
+                'error_line' => $error->getLine(),
+                'stack_trace' => $error->getTraceAsString()
+            ]);
+            
+            return $this->errorResponse($error->getMessage());
         }
+    }
 
-        return $rss->asXML();
+    /**
+     * Return an error response as XML format.
+     * @param string $message
+     * @return \Illuminate\Http\Response
+     */
+    private function errorResponse($message)
+    {
+        $xml = new SimpleXMLElement('<response/>');
+        $xml->addChild('code', 500);
+        $xml->addChild('status', 'error');
+        $xml->addChild('message', $message);
+        $xml->addChild('content', '');
+
+        // Format the XML with line breaks and indentation
+        $dom = new \DOMDocument('1.0', 'UTF-8');
+        $dom->preserveWhiteSpace = false;
+        $dom->formatOutput = true;
+        $dom->loadXML($xml->asXML());
+
+        return response($dom->saveXML(), 500)
+            ->header('Content-Type', 'application/rss+xml');
     }
 
 }

--- a/app/Services/RssFeedService.php
+++ b/app/Services/RssFeedService.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Http;
+use SimpleXMLElement;
+use Exception;
+use Illuminate\Support\Facades\Log;
+
+class RssFeedService
+{
+    /**
+     * Fetches the RSS feed for the specified section.
+     * This method attempts to retrieve the RSS feed for the given section by calling the `getRssFeedFromApi` method.
+     * @param string $section The section for which to fetch the RSS feed.
+     * @return string Returns the RSS feed as XML if the fetch is successful.
+     * @throws \Exception If the RSS feed cannot be fetched from the API.
+     */
+    public function fetchRssFeed(string $section)
+    {
+        $rssFeed = $this->getRssFeedFromApi($section);
+
+        if (!$rssFeed) {
+            throw new Exception('Unable to fetch RSS feed');
+        }
+
+        return $rssFeed;
+    }
+    
+    /**
+     * Retrieves the RSS feed data from the Guardian API.
+     * This method sends an HTTP GET request to the Guardian API to fetch data for the specified section.
+     * If the request fails, it returns null. Otherwise, it processes the response and converts it into RSS format.
+     * @param string $section The section for which to fetch the RSS feed data.
+     * @return string|null Returns the RSS feed as XML if the API request is successful or null if the request fails.
+     */
+    private function getRssFeedFromApi(string $section)
+    {
+        $response = Http::get(env('GUARDAIN_URL').'sections', [
+            'q' => $section,
+            'api-key' => env('GUARDAIN_API_KEY'),
+            'format' => 'json',
+        ]);
+
+        if ($response->failed()) {
+            return null;
+        }
+
+        $data = $response->json();
+        Log::info('Response from GUARDAIN', ['data' => $data]);
+        return $this->convertToRss($data);
+    }
+
+    /**
+     * Converts the API response data into an RSS feed format.
+     * This method takes the raw JSON data from the Guardian API and converts it into an RSS 2.0 XML format.
+     * Each article in the response is represented as an RSS item, with the title and link of the article.
+     * @param array $data The data returned by the API in JSON format.
+     * @return string Returns the RSS feed as XML.
+     */
+    private function convertToRss(array $data)
+    {
+        $rss = new SimpleXMLElement('<rss/>');
+        $rss->addAttribute('version', '2.0');
+        $channel = $rss->addChild('channel');
+        $channel->addChild('title', 'The Guardian RSS Feed');
+        $channel->addChild('link', 'https://www.theguardian.com');
+
+        foreach ($data['response']['results'] as $article) {
+            $rssItem = $channel->addChild('item');
+            $rssItem->addChild('title', htmlspecialchars($article['webTitle']));
+            $rssItem->addChild('link', htmlspecialchars($article['webUrl']));
+        }
+
+        // Format the XML with line breaks and indentation
+        $dom = new \DOMDocument('1.0', 'UTF-8');
+        $dom->preserveWhiteSpace = false;
+        $dom->formatOutput = true;
+        $dom->loadXML($rss->asXML());
+
+        return $dom->saveXML();
+    }
+}


### PR DESCRIPTION
- Created the RssFeedService:
   - to retrieves the RSS feed data from the Guardian API based on section.
   - to converts the API response data into an RSS feed format.
   - to returns the RSS feed as XML if the fetch is successful.
-  Implemented the RssFeedService in RssFeedController:
   - Injected RssFeedService into the controller.
   - Integrated the service to fetch the RSS feed and return it.
   - Added exception handling to ensure proper error reporting.
- Error Handling:
  - A try-catch block is used in the controller to catch any exceptions that occur during the fetching of the RSS feed.
  - Error responses are returned in an XML format to maintain consistency with the RSS feed output.
  - Custom XML error messages include code, status, message, and content to provide clear error information